### PR TITLE
MA-3711/ Enable the CloudCheckr StateMachine  if cloudcheckr flag is set to true

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -549,7 +549,23 @@ Resources:
               "Type": "Task",
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Update-Db",
               "InputPath": "$",
-              "Next": "TriggerCloudCheckr"
+              "Next": "CloudcheckrChoiceState"
+            },
+            "CloudcheckrChoiceState": {
+              "Type" : "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.cloudcheckr.isCloudcheckrEnabled",
+                  "StringEquals": "true",
+                  "Next": "TriggerCloudCheckr"
+                },
+                {
+                  "Variable": "$.cloudcheckr.isCloudcheckrEnabled",
+                  "StringEquals": "false",
+                  "Next": "SetupHealthAlert"
+                }
+              ],
+              "Default": "SetupHealthAlert"
             },
             "TriggerCloudCheckr": {
               "Type" : "Task",

--- a/template.yaml
+++ b/template.yaml
@@ -555,12 +555,12 @@ Resources:
               "Type" : "Choice",
               "Choices": [
                 {
-                  "Variable": "$.cloudcheckr.isCloudcheckrEnabled",
+                  "Variable": "$.cloudcheckr.enableCloudCheckr",
                   "StringEquals": "true",
                   "Next": "TriggerCloudCheckr"
                 },
                 {
-                  "Variable": "$.cloudcheckr.isCloudcheckrEnabled",
+                  "Variable": "$.cloudcheckr.enableCloudCheckr",
                   "StringEquals": "false",
                   "Next": "SetupHealthAlert"
                 }


### PR DESCRIPTION
Purpose : 

If the enable cloudcheckr flag is set to false the CloudCheckr StateMachine should not be executed

Changes : 

Added the new step (choice) in  the Onboarding state machine to check the variable value. If it is set to "true" then triggerCloudcheckr step will be executed to enable cloudcheckr otherwise it will be skipped.  

Testing : 

Testing is done manually.