### PR TITLE
MA-3750/ Create Global CloudTrail for new customers

### DIFF
--- a/src/index_find_regions.js
+++ b/src/index_find_regions.js
@@ -17,7 +17,8 @@ exports.handler = (event, context, callback) => {
     }
     event.awsevents.Credentials = credentials;
     credentials = new Buffer(JSON.stringify(credentials)).toString('base64');
-    event.cloudtrail.headers.Credentials = credentials;
+    var cloudtrailResult = JSON.parse(event.cloudtrail.result.body);
+    event.final_result.cloudtrail[event.cloudtrail.body.region] = cloudtrailResult.result;
     event.awsconfig.headers.Credentials = credentials;
     event.configrules.headers.Credentials = credentials;
     console.log(event);

--- a/src/index_health_stack.js
+++ b/src/index_health_stack.js
@@ -24,6 +24,7 @@ exports.handler = function (event, context) {
 
   event.cloudtrail.queryStringParameters.region = process.env.AWS_DEFAULT_REGION;
   event.cloudtrail.body.region = process.env.AWS_DEFAULT_REGION;
+  event.cloudtrail.headers.Credentials = creds;
 
   // create cloudformation and codepipeline roles first if not exist
   createRole(creds, input.cloudformationLambdaExecutionRole, function(err, data) {

--- a/src/index_health_stack.js
+++ b/src/index_health_stack.js
@@ -22,6 +22,9 @@ exports.handler = function (event, context) {
     sessionToken: input.credentials.SessionToken
   });
 
+  event.cloudtrail.queryStringParameters.region = process.env.AWS_DEFAULT_REGION;
+  event.cloudtrail.body.region = process.env.AWS_DEFAULT_REGION;
+
   // create cloudformation and codepipeline roles first if not exist
   createRole(creds, input.cloudformationLambdaExecutionRole, function(err, data) {
     if (err) {

--- a/src/index_next_region.js
+++ b/src/index_next_region.js
@@ -2,8 +2,6 @@
 exports.handler = (event, context, callback) => {
   var region = event.regions.shift();
   event.num_of_regions = event.regions.length;
-  event.cloudtrail.queryStringParameters.region = region;
-  event.cloudtrail.body.region = region;
   event.awsconfig.queryStringParameters.region = region;
   event.awsconfig.body.region = region;
   event.configrules.queryStringParameters.region = region;

--- a/src/index_set_results.js
+++ b/src/index_set_results.js
@@ -1,11 +1,9 @@
 
 exports.handler = (event, context, callback) => {
   // we've got all outputs of the parallel actions, so merge results to the first action's output
-  var cloudtrailResult = JSON.parse(event[0].cloudtrail.result.body);
-  event[0].final_result.cloudtrail[event[0].cloudtrail.body.region] = cloudtrailResult.result;
-  var awsconfigResult = JSON.parse(event[1].awsconfig.result.body);
-  event[0].final_result.awsconfig[event[0].awsconfig.body.region] = awsconfigResult.result;
-  var awseventsResult = JSON.stringify(event[0].awsevents.result);
-  event[0].final_result.awsevents[event[0].awsevents.body.region] = awseventsResult;
-  callback(null, event[0]);
+  var awsconfigResult = JSON.parse(event.awsconfig.result.body);
+  event.final_result.awsconfig[event.awsconfig.body.region] = awsconfigResult.result;
+  var awseventsResult = JSON.stringify(event.awsevents.result);
+  event.final_result.awsevents[event.awsevents.body.region] = awseventsResult;
+  callback(null, event);
 };

--- a/src/json/state_machine_input.json
+++ b/src/json/state_machine_input.json
@@ -40,10 +40,12 @@
       "Credentials": null
     },
     "queryStringParameters": {
-      "region": null
+      "region": null,
+      "multiRegion": true
     },
     "body": {
-      "region": null
+      "region": null,
+      "multiRegion": true
     },
     "result": null
   },

--- a/template.yaml
+++ b/template.yaml
@@ -577,6 +577,13 @@ Resources:
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Setup-Health",
               "InputPath": "$.health",
               "ResultPath": "$.health.result",
+              "Next": "CloudtrailActionState"
+            },
+            "CloudtrailActionState": {
+              "Type": "Task",
+              "Resource": "arn:aws:lambda:us-east-1:622821376834:function:SungardAS-CloudTrail",
+              "InputPath": "$.cloudtrail",
+              "ResultPath": "$.cloudtrail.result",
               "Next": "FindRegionsState"
             },
             "FindRegionsState": {
@@ -604,50 +611,27 @@ Resources:
             "NextRegionState": {
               "Type" : "Task",
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Next-Region",
-              "Next": "Parallel"
+              "Next": "AWSConfigActionState"
             },
-            "Parallel": {
-              "Type": "Parallel",
-              "Next": "AWSConsoleSignInAlertState",
-              "Branches": [
-                {
-                  "StartAt": "CloudtrailActionState",
-                  "States": {
-                    "CloudtrailActionState": {
-                      "Type" : "Task",
-                      "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-CloudTrail",
-                      "InputPath": "$.cloudtrail",
-                      "ResultPath": "$.cloudtrail.result",
-                      "End": true
-                    }
-                  }
-                },
-                {
-                  "StartAt": "AWSConfigActionState",
-                  "States": {
-                    "AWSConfigActionState": {
-                      "Type" : "Task",
-                      "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-AWSConfig",
-                      "InputPath": "$.awsconfig",
-                      "ResultPath": "$.awsconfig.result",
-                      "End": true
-                    }
-                  }
-                }
-              ]
+            "AWSConfigActionState": {
+              "Type" : "Task",
+              "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-AWSConfig",
+              "InputPath": "$.awsconfig",
+              "ResultPath": "$.awsconfig.result",
+              "Next": "AWSConsoleSignInAlertState"
             },
             "AWSConsoleSignInAlertState": {
                "Type" : "Task",
                "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Set-Console-Sign-In-Alert",
-               "InputPath": "$[0].awsevents",
-               "ResultPath": "$[0].awsevents.result",
+               "InputPath": "$.awsevents",
+               "ResultPath": "$.awsevents.result",
                "Next": "ConfigRulesActionState"
             },
             "ConfigRulesActionState": {
               "Type": "Task",
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-ConfigRules",
-              "InputPath": "$[0].configrules",
-              "ResultPath": "$[0].configrules.result",
+              "InputPath": "$.configrules",
+              "ResultPath": "$.configrules.result",
               "Next": "SetResultsState"
             },
             "SetResultsState": {


### PR DESCRIPTION
Purpose :

Currently we are enabling cloudtrail in every region for new customer in the onboarding process but now create Global CloudTrail for new customers in the onboarding state machine flow.

Changes :

Currently we were enabling cloudtrail for all regions through the state machine now modified the state machine flow to run cloudtrail lambda only once to enable global cloudtrail. 

Also modified the below files to handle input and output concerning the cloudtrail lambda function and removed the older logic to handle the cloudtrail result for multiple regions.

Files modified:

- index_find_regions.js

- index_health_stack.js

-  index_next_region.js

- index_set_results.js

- state_machine_input.json

- template.yaml