### PR TITLE
Ma 3750/Create Global CloudTrail for new customers

### DIFF
--- a/src/index_set_results.js
+++ b/src/index_set_results.js
@@ -1,8 +1,10 @@
 
 exports.handler = (event, context, callback) => {
   // we've got all outputs of the parallel actions, so merge results to the first action's output
-  var cloudtrailResult = JSON.parse(event[0].cloudtrail.result.body);
-  event[0].final_result.cloudtrail[event[0].cloudtrail.body.region] = cloudtrailResult.result;
+  if(event[0].cloudtrail.result != null){
+    var cloudtrailResult = JSON.parse(event[0].cloudtrail.result.body);
+    event[0].final_result.cloudtrail[event[0].cloudtrail.body.region] = cloudtrailResult.result;
+  }
   var awsconfigResult = JSON.parse(event[1].awsconfig.result.body);
   event[0].final_result.awsconfig[event[0].awsconfig.body.region] = awsconfigResult.result;
   var awseventsResult = JSON.stringify(event[0].awsevents.result);

--- a/src/json/state_machine_input.json
+++ b/src/json/state_machine_input.json
@@ -40,10 +40,12 @@
       "Credentials": null
     },
     "queryStringParameters": {
-      "region": null
+      "region": null,
+      "multiRegion": true
     },
     "body": {
-      "region": null
+      "region": null,
+      "multiRegion": true
     },
     "result": null
   },

--- a/template.yaml
+++ b/template.yaml
@@ -611,14 +611,34 @@ Resources:
               "Next": "AWSConsoleSignInAlertState",
               "Branches": [
                 {
-                  "StartAt": "CloudtrailActionState",
+                  "StartAt": "CloudtrailChoiceState",
                   "States": {
+                    "CloudtrailChoiceState": {
+                      "Type" : "Choice",
+                      "Choices": [
+                        {
+                          "Variable": "$.cloudtrail.body.region",
+                          "StringEquals": "us-east-1",
+                          "Next": "CloudtrailActionState"
+                        },
+                        {
+                          "Variable": "$.cloudtrail.body.region",
+                          "StringEquals": "us-west-2",
+                          "Next": "CloudtrailActionState"
+                        }
+                      ],
+                      "Default": "Done"
+                    },
                     "CloudtrailActionState": {
                       "Type" : "Task",
                       "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-CloudTrail",
                       "InputPath": "$.cloudtrail",
                       "ResultPath": "$.cloudtrail.result",
                       "End": true
+                    },
+                    "Done": {
+                    "Type": "Pass",
+                    "End": true
                     }
                   }
                 },

--- a/template.yaml
+++ b/template.yaml
@@ -627,7 +627,7 @@ Resources:
                           "Next": "CloudtrailActionState"
                         }
                       ],
-                      "Default": "Done"
+                      "Default": "PassCloudtrailActionState"
                     },
                     "CloudtrailActionState": {
                       "Type" : "Task",
@@ -636,7 +636,7 @@ Resources:
                       "ResultPath": "$.cloudtrail.result",
                       "End": true
                     },
-                    "Done": {
+                    "PassCloudtrailActionState": {
                     "Type": "Pass",
                     "End": true
                     }


### PR DESCRIPTION
Purpose :

Currently we are enabling cloudtrail in every region for new customer in the onboarding process but now create Global CloudTrail for new customers in the onboarding state machine flow.

Changes :

Currently we were enabling cloudtrail for all regions through the state machine now modified the state machine flow to run cloudtrail lambda only for two (priary and secobdary ) regions to enable global cloudtrail.

Files modified:

index_set_results.js

state_machine_input.json

template.yaml