### PR TITLE
State machine vpc pre config/ma 2670

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -577,8 +577,18 @@ Resources:
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Setup-Health",
               "InputPath": "$.health",
               "ResultPath": "$.health.result",
+              "Next": "TriggerPreconfig"
+            },
+
+            "TriggerPreconfig": {
+              "Type": "Task",
+              "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:ManagedVpcPreConfig-Trigger-StateMachine ",
+              "InputPath": "$",
+              "ResultPath": "$",
               "Next": "FindRegionsState"
             },
+
+
             "FindRegionsState": {
               "Type": "Task",
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Find-Regions",


### PR DESCRIPTION
Description
Purpose :

Modiy the template.yaml file for adding a step in the onboarding state machine. This step is for Managed VPC preconfig.

Changes :

Following are major changes :

Modified template.yaml file for adding preconfig step in onboarding state machine.
Testing :

Testing is done in dev environment.