### PR TITLE
MA-4040: Modifed update db step to add craws account roles into database

### DIFF
--- a/src/index_update_db.js
+++ b/src/index_update_db.js
@@ -33,30 +33,26 @@ exports.handler = function(event, context, callback) {
              else return accResp.create(dbAwsAccount);
          })
           .then(accData => {
-            if (dbAwsAccount.account_type.toLowerCase() != 'craws') {
-              for (let idx = 0; idx < dbIamRoles.length; idx++) {
-                dbIamRoles[idx].account = accData.dataValues.id;
-                mcawsDbObj.AwsIamRole(iamResp =>
-                  iamResp.findOne({
-                     where: {arn: dbIamRoles[idx].arn}
-                  })
-                  .then(resultData =>{
-                    if(resultData) {
-                       console.log("IAM Role entry is already there.");
-                       return resultData;
-                    }
-                    else return iamResp.create(dbIamRoles[idx]);
-                  })
-                    .then(roleData => {
-                      console.log('role updation Done :)');
-                      console.log(roleData);
-                      if (idx == dbIamRoles.length - 1) mcawsDbObj.CloseConnection();
-                    })
-                    .catch(errRole => console.log(errRole))
-                );
-              }
-            } else {
-              mcawsDbObj.CloseConnection();
+            for (let idx = 0; idx < dbIamRoles.length; idx++) {
+              dbIamRoles[idx].account = accData.dataValues.id;
+              mcawsDbObj.AwsIamRole(iamResp =>
+                iamResp.findOne({
+                   where: {arn: dbIamRoles[idx].arn}
+                })
+                .then(resultData =>{
+                  if(resultData) {
+                     console.log("IAM Role entry is already there.");
+                     return resultData;
+                  }
+                  else return iamResp.create(dbIamRoles[idx]);
+                })
+                .then(roleData => {
+                  console.log('role updation Done :)');
+                  console.log(roleData);
+                  if (idx == dbIamRoles.length - 1) mcawsDbObj.CloseConnection();
+                })
+                .catch(errRole => console.log(errRole))
+              );
             }
           })
           .catch(errAcc => console.log(errAcc))

--- a/src/index_update_db.js
+++ b/src/index_update_db.js
@@ -49,9 +49,9 @@ exports.handler = function(event, context, callback) {
                 .then(roleData => {
                   console.log('role updation Done :)');
                   console.log(roleData);
-                  if (idx == dbIamRoles.length - 1) mcawsDbObj.CloseConnection();
                 })
                 .catch(errRole => console.log(errRole))
+                .finally(() => mcawsDbObj.CloseConnection())
               );
             }
           })


### PR DESCRIPTION
Modified update db step to add craws account roles into database.

Tested the complete flow for all three types of accounts. Self managed alone fails in TriggerPreconfig step which is irrelevant to this modification of update database.

Roles get added for all three type accounts in awsiamrole table