### PR TITLE
added wait condition to delay federation execution

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -527,11 +527,6 @@ Resources:
               "Type": "Task",
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Pre-New-Federation",
               "InputPath": "$",
-              "Next": "WaitCondition"
-            },
-            "WaitCondition": {
-              "Type": "Wait",
-              "Seconds": 20,
               "Next": "NewAccountFederation"
             },
             "NewAccountFederation": {
@@ -539,6 +534,14 @@ Resources:
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Federation",
               "InputPath": "$.federation",
               "ResultPath": "$.credentials",
+              "Retry": [
+                {
+                  "ErrorEquals": ["AccessDenied"],
+                  "IntervalSeconds": 10,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2.0
+                }
+              ],
               "Next": "SetNewAccountCredentials"
             },
             "SetNewAccountCredentials": {
@@ -763,11 +766,6 @@ Resources:
               "Type": "Task",
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Pre-New-Federation",
               "InputPath": "$",
-              "Next": "WaitCondition"
-            },
-            "WaitCondition": {
-              "Type": "Wait",
-              "Seconds": 20,
               "Next": "NewAccountFederation"
             },
             "NewAccountFederation": {
@@ -775,6 +773,14 @@ Resources:
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Federation",
               "InputPath": "$.federation",
               "ResultPath": "$.credentials",
+              "Retry": [
+                {
+                  "ErrorEquals": ["AccessDenied"],
+                  "IntervalSeconds": 10,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2.0
+                }
+              ],
               "Next": "SetNewAccountCredentials"
             },
             "SetNewAccountCredentials": {

--- a/template.yaml
+++ b/template.yaml
@@ -527,6 +527,11 @@ Resources:
               "Type": "Task",
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Pre-New-Federation",
               "InputPath": "$",
+              "Next": "WaitCondition"
+            },
+            "WaitCondition": {
+              "Type": "Wait",
+              "Seconds": 20,
               "Next": "NewAccountFederation"
             },
             "NewAccountFederation": {
@@ -758,6 +763,11 @@ Resources:
               "Type": "Task",
               "Resource": "arn:aws:lambda:AWS::REGION:AWS::ACCOUNT_ID:function:SungardAS-Onboarding-Pre-New-Federation",
               "InputPath": "$",
+              "Next": "WaitCondition"
+            },
+            "WaitCondition": {
+              "Type": "Wait",
+              "Seconds": 20,
               "Next": "NewAccountFederation"
             },
             "NewAccountFederation": {


### PR DESCRIPTION
Purpose:

Self-Managed and unManaged account creation is failing in QA at NewAccountFederation step of the respective state machine.

Changes:

1) template.yaml : added the wait condition for both the state machines (managed/un-managed) before the "NewAccountFederation" to prevent inconsistency of failure at this step.

Testing 

Tested successfully on QA.

Eslint:

NA

Screenshot:

![image](https://user-images.githubusercontent.com/10847629/46744727-5c125c00-ccc9-11e8-9123-2602c258829f.png)
